### PR TITLE
megaHH-59, megaHH-66. Фикс багов.

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/ui/search/SearchVacancyFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/search/SearchVacancyFragment.kt
@@ -33,7 +33,7 @@ class SearchVacancyFragment : Fragment() {
     private var _binding: FragmentVacancySearchBinding? = null
     private val binding get() = _binding!!
 
-    private lateinit var debouncer: Debouncer
+    private var debouncer: Debouncer? = null
 
     private var vacancyAdapter: VacancyAdapter? = null
     private var isKeyboardVisible = false
@@ -88,7 +88,7 @@ class SearchVacancyFragment : Fragment() {
                 updateSearchIcon(text.toString())
 
                 if (text.toString().isNotBlank()) {
-                    debouncer.debounce {
+                    debouncer?.debounce {
                         val queryString = binding.searchEditText.text.toString()
                         if (queryString.isNotBlank()) {
                             query = queryString


### PR DESCRIPTION
1. Правлю баг с возвратом с экрана избранного. Баг был из-за того, что дебаунсер нельзя инициализировать лениво. Если использовать lazy, то он инициализируется только при первом обращении. Если фрагмент пересоздается viewLifecycleOwner.lifecycleScope может измениться, но старый дебаунсер сохранится. В результате если внутри у него проверить scope.isActive, то получим false. 
2. Правлю видимость прогрессБара при инитном положении "пустой поисковый запрос". Добавляю наблюдение за 2 способами очистки: по крестику И руками по символу через backspace.