### PR TITLE
megaHH-104. Правки по плейсхолдерам

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/ui/filter/industry/IndustryFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/filter/industry/IndustryFragment.kt
@@ -111,21 +111,50 @@ class IndustryFragment : Fragment() {
         }
     }
 
-    private fun showError(screenState: IndustryScreenState) {
-        binding.industryList.gone()
+    private fun showError(screenState: IndustryScreenState) =
         when (screenState) {
-            is IndustryScreenState.Error -> binding.placeholderEmptyList.root.show()
-            is IndustryScreenState.NoInternet -> binding.placeholderNoInternet.root.show()
-            is IndustryScreenState.NothingFound -> binding.placeholderNotFound.root.show()
+            is IndustryScreenState.NoInternet -> setNoInternetState()
+            is IndustryScreenState.Error -> setServerErrorState()
+            is IndustryScreenState.NothingFound -> setNothingFoundState()
             else -> {}
         }
-    }
+
 
     private fun showContent(industries: List<FilterParam>) {
         binding.progressBar.gone()
         binding.industryList.show()
         adapter?.updateItems(industries, viewModel.selectedIndustry.value)
         adapter?.notifyDataSetChanged()
+    }
+
+    private fun setServerErrorState() {
+        listOf(
+            binding.progressBar,
+            binding.industryList,
+            binding.placeholderNotFound.root,
+            binding.placeholderNoInternet.root,
+        ).gone()
+        binding.placeholderEmptyList.root.show()
+    }
+
+    private fun setNoInternetState() {
+        listOf(
+            binding.progressBar,
+            binding.industryList,
+            binding.placeholderEmptyList.root,
+            binding.placeholderNotFound.root,
+        ).gone()
+        binding.placeholderNoInternet.root.show()
+    }
+
+    private fun setNothingFoundState() {
+        listOf(
+            binding.progressBar,
+            binding.industryList,
+            binding.placeholderEmptyList.root,
+            binding.placeholderNoInternet.root,
+        ).gone()
+        binding.placeholderNotFound.root.show()
     }
 
     private fun onIndustrySelected(industry: FilterParam) {

--- a/app/src/main/java/ru/practicum/android/diploma/ui/filter/industry/IndustryFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/filter/industry/IndustryFragment.kt
@@ -129,6 +129,7 @@ class IndustryFragment : Fragment() {
 
     private fun setServerErrorState() {
         listOf(
+            binding.searchContainer,
             binding.progressBar,
             binding.industryList,
             binding.placeholderNotFound.root,
@@ -139,6 +140,7 @@ class IndustryFragment : Fragment() {
 
     private fun setNoInternetState() {
         listOf(
+            binding.searchContainer,
             binding.progressBar,
             binding.industryList,
             binding.placeholderEmptyList.root,
@@ -149,6 +151,7 @@ class IndustryFragment : Fragment() {
 
     private fun setNothingFoundState() {
         listOf(
+            binding.searchContainer,
             binding.progressBar,
             binding.industryList,
             binding.placeholderEmptyList.root,


### PR DESCRIPTION
Немного поправила логику плейсхолдеров, НО концептуально сильно ничего не поменялось, т.к. при отсутствии интернета у нас появляется плейсхолдер "нет интернета" **при открытии экрана с отраслями** (дополнительно добавила тут скрытие поля поиска, чтобы не получилось ничего поискать).
 А вот поиск отраслей уже происходит без походов в сеть, поиск на уровне вью модели. Показывать здесь ошибку "нет интернета", кмк нелогично. Поиск нормально может пройти и без интернета, если уже успел загрузиться список отраслей. Если ищем что-то, что есть в списке, я вижу результат, если нет - то норм ошибка, что ничего не найдено.